### PR TITLE
Update pygeoprocessing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ notebooks = ["*.ipynb"]
 name = "invest-schistosomiasis"
 dynamic = ["version"]
 dependencies = [
-  "pygeoprocessing",
+  "pygeoprocessing<2.4.10",
   "taskgraph",
   "matplotlib",
 #"natcap.invest @ git+https://github.com/natcap/schistosomiasis-invest.git@schistosomiasis",


### PR DESCRIPTION
Cap the pygeoprocessing dependency because of a backward incompatible change in 2.4.10